### PR TITLE
Bugfixes to fp_prime_random_ex

### DIFF
--- a/src/headers/tfm.h
+++ b/src/headers/tfm.h
@@ -253,7 +253,7 @@
 #else
    /* this is to make porting into LibTomCrypt easier :-) */
 #ifndef CRYPT
-   #if defined(_MSC_VER) || defined(__BORLANDC__) 
+   #if defined(_MSC_VER) || defined(__BORLANDC__)
       typedef unsigned __int64   ulong64;
       typedef signed __int64     long64;
    #else

--- a/src/headers/tfm.h
+++ b/src/headers/tfm.h
@@ -1,10 +1,10 @@
 /* TomsFastMath, a fast ISO C bignum library.
- * 
+ *
  * This project is meant to fill in where LibTomMath
  * falls short.  That is speed ;-)
  *
  * This project is public domain and free for all purposes.
- * 
+ *
  * Tom St Denis, tomstdenis@gmail.com
  */
 #ifndef TFM_H_
@@ -27,13 +27,13 @@
 /* externally define this symbol to ignore the default settings, useful for changing the build from the make process */
 #ifndef TFM_ALREADY_SET
 
-/* do we want the large set of small multiplications ? 
+/* do we want the large set of small multiplications ?
    Enable these if you are going to be doing a lot of small (<= 16 digit) multiplications say in ECC
    Or if you're on a 64-bit machine doing RSA as a 1024-bit integer == 16 digits ;-)
  */
 #define TFM_SMALL_SET
 
-/* do we want huge code 
+/* do we want huge code
    Enable these if you are doing 20, 24, 28, 32, 48, 64 digit multiplications (useful for RSA)
    Less important on 64-bit machines as 32 digits == 2048 bits
  */
@@ -81,7 +81,7 @@
 /* #define TFM_PRESCOTT */
 
 /* Do we want timing resistant fp_exptmod() ?
- * This makes it slower but also timing invariant with respect to the exponent 
+ * This makes it slower but also timing invariant with respect to the exponent
  */
 /* #define TFM_TIMING_RESISTANT */
 
@@ -106,7 +106,7 @@
 
 /* autodetect x86-64 and make sure we are using 64-bit digits with x86-64 asm */
 #if defined(__x86_64__)
-   #if defined(TFM_X86) || defined(TFM_SSE2) || defined(TFM_ARM) 
+   #if defined(TFM_X86) || defined(TFM_SSE2) || defined(TFM_ARM)
        #error x86-64 detected, x86-32/SSE2/ARM optimizations are not valid!
    #endif
    #if !defined(TFM_X86_64) && !defined(TFM_NO_ASM)
@@ -121,7 +121,7 @@
 
 /* try to detect x86-32 */
 #if defined(__i386__) && !defined(TFM_SSE2)
-   #if defined(TFM_X86_64) || defined(TFM_ARM) 
+   #if defined(TFM_X86_64) || defined(TFM_ARM)
        #error x86-32 detected, x86-64/ARM optimizations are not valid!
    #endif
    #if !defined(TFM_X86) && !defined(TFM_NO_ASM)
@@ -185,7 +185,7 @@
    #undef TFM_PPC32
    #undef TFM_PPC64
    #undef TFM_AVR32
-   #undef TFM_ASM   
+   #undef TFM_ASM
 #endif
 
 /* ECC helpers */
@@ -249,6 +249,7 @@
 #endif
    typedef ulong64            fp_digit;
    typedef unsigned long      fp_word __attribute__ ((mode(TI)));
+   #define DIGIT_SHIFT        6
 #else
    /* this is to make porting into LibTomCrypt easier :-) */
 #ifndef CRYPT
@@ -262,6 +263,7 @@
 #endif
    typedef unsigned long      fp_digit;
    typedef ulong64            fp_word;
+   #define DIGIT_SHIFT        5
 #endif
 
 /* # of digits this is */
@@ -290,7 +292,7 @@
 /* a FP type */
 typedef struct {
     fp_digit dp[FP_SIZE];
-    int      used, 
+    int      used,
              sign;
 } fp_int;
 
@@ -434,9 +436,9 @@ int fp_isprime(fp_int *a);
 /* callback for fp_prime_random, should fill dst with random bytes and return how many read [upto len] */
 typedef int tfm_prime_callback(unsigned char *dst, int len, void *dat);
 
-#define fp_prime_random(a, t, size, bbs, cb, dat) fp_prime_random_ex(a, t, ((size) * 8) + 1, (bbs==1)?TFM_PRIME_BBS:0, cb, dat)
+#define fp_prime_random(a, size, bbs, cb, dat) fp_prime_random_ex(a, ((size) * 8) + 1, (bbs==1)?TFM_PRIME_BBS:0, cb, dat)
 
-int fp_prime_random_ex(fp_int *a, int t, int size, int flags, tfm_prime_callback cb, void *dat);
+int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, void *dat);
 
 /* radix conersions */
 int fp_count_bits(fp_int *a);

--- a/src/numtheory/fp_prime_random_ex.c
+++ b/src/numtheory/fp_prime_random_ex.c
@@ -35,7 +35,7 @@ int fp_prime_random_ex(fp_int *a, int t, int size, int flags, tfm_prime_callback
    }
 
    /* calc the maskAND value for the MSbyte*/
-   maskAND = 0xFF >> (8 - (size & 7));
+   maskAND = 0xFF >> ((8 - (size & 7)) & 7);
 
    /* calc the maskOR_msb */
    maskOR_msb        = 0;

--- a/src/numtheory/fp_prime_random_ex.c
+++ b/src/numtheory/fp_prime_random_ex.c
@@ -55,6 +55,10 @@ int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, vo
       /* make sure the MSbyte has the required number of bits */
       a->dp[dsize-1]    &= maskAND_msb;
 
+      /* Force a->used as well, it could be smaller if the highest bits were
+         generated as 0 by the callback. */
+      a->used           = dsize;
+
       /* modify the LSbyte as requested */
       a->dp[0]          |= maskOR_lsb;
 

--- a/src/numtheory/fp_prime_random_ex.c
+++ b/src/numtheory/fp_prime_random_ex.c
@@ -10,10 +10,10 @@
 #include <tfm.h>
 
 #define fp_on_bitnum(a, bitnum) \
-    a->dp[(bitnum) >> DIGIT_SHIFT] |= 1 << ((bitnum) & (DIGIT_BIT-1));
+    a->dp[(bitnum) >> DIGIT_SHIFT] |= (fp_digit)1 << ((bitnum) & (DIGIT_BIT-1))
 
 #define fp_off_bitnum(a, bitnum) \
-    a->dp[(bitnum) >> DIGIT_SHIFT] &= ~(1 << ((bitnum) & (DIGIT_BIT-1)));
+    a->dp[(bitnum) >> DIGIT_SHIFT] &= ~((fp_digit)1 << ((bitnum) & (DIGIT_BIT-1)))
 
 /* This is possibly the mother of all prime generation functions, muahahahahaha! */
 int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, void *dat)

--- a/src/numtheory/fp_prime_random_ex.c
+++ b/src/numtheory/fp_prime_random_ex.c
@@ -37,7 +37,7 @@ int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, vo
    bsize = (size + 7) >> 3;
 
    /* calc the maskAND value for the MSbyte */
-   maskAND_msb = FP_MASK >> ((DIGIT_BIT - (size & (DIGIT_BIT-1))) & (DIGIT_BIT-1));
+   maskAND_msb = FP_MASK >> ((DIGIT_BIT - size) & (DIGIT_BIT-1));
 
    /* get the maskOR_lsb */
    maskOR_lsb         = 1;

--- a/src/numtheory/fp_prime_random_ex.c
+++ b/src/numtheory/fp_prime_random_ex.c
@@ -19,7 +19,8 @@
 int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, void *dat)
 {
    fp_digit maskAND_msb, maskOR_lsb;
-   int res, err, bsize, dsize;
+   int res, bsize, dsize;
+   unsigned char buf[FP_SIZE * sizeof(fp_digit)];
 
    /* sanity check the input */
    if (size <= 1) {
@@ -33,6 +34,7 @@ int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, vo
 
    /* calc the digit size */
    dsize = (size + DIGIT_BIT - 1) >> DIGIT_SHIFT;
+   bsize = (size + 7) >> 3;
 
    /* calc the maskAND value for the MSbyte */
    maskAND_msb = FP_MASK >> ((DIGIT_BIT - (size & (DIGIT_BIT-1))) & (DIGIT_BIT-1));
@@ -45,10 +47,10 @@ int fp_prime_random_ex(fp_int *a, int size, int flags, tfm_prime_callback cb, vo
 
    do {
       /* read the bytes */
-      if (cb((unsigned char*)&a->dp[0], dsize*DIGIT_BIT, dat) != dsize*DIGIT_BIT) {
+      if (cb(buf, bsize, dat) != bsize) {
          return FP_VAL;
       }
-      a->used = dsize;
+      fp_read_unsigned_bin(a, buf, bsize);
 
       /* make sure the MSbyte has the required number of bits */
       a->dp[dsize-1]    &= maskAND_msb;


### PR DESCRIPTION
This branch contains some fixes to fp_prime_random_ex. See the specific commits. Specifically:

1) Remove unused "t" parameter.
2) Avoid generating primes with MSB=0x80 when size is a multiple of 8
3) Avoid usage of malloc()
