### PR TITLE
Extend travis-ci file with GCC 4.9 and also a set of shared library builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: c
 compiler:
   - gcc
-script: CC="${MYCC}" make test >test_gcc_1.txt 2>test_gcc_2.txt && ./test >test_std.txt 2>test_err.txt
+script: CC="${MYCC}" make ${SHARED} test >test_gcc_1.txt 2>test_gcc_2.txt && ./test >test_std.txt 2>test_err.txt
 env:
-  - MYCC="gcc"
-  - MYCC="gcc -m32"
-  - MYCC="gcc-4.8"
-  - MYCC="gcc-4.8 -m32"
-  - MYCC="gcc-4.9"
-  - MYCC="gcc-4.9 -m32"
+  - MYCC="gcc" SHARED=""
+  - MYCC="gcc -m32" SHARED=""
+  - MYCC="gcc-4.8" SHARED=""
+  - MYCC="gcc-4.8 -m32" SHARED=""
+  - MYCC="gcc-4.9" SHARED=""
+  - MYCC="gcc-4.9 -m32" SHARED=""
+  - MYCC="gcc" SHARED="-f makefile.shared"
+  - MYCC="gcc -m32" SHARED="-f makefile.shared"
+  - MYCC="gcc-4.8" SHARED="-f makefile.shared"
+  - MYCC="gcc-4.8 -m32" SHARED="-f makefile.shared"
+  - MYCC="gcc-4.9" SHARED="-f makefile.shared"
+  - MYCC="gcc-4.9 -m32" SHARED="-f makefile.shared"
 matrix:
   fast_finish: true
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ env:
   - MYCC="gcc -m32"
   - MYCC="gcc-4.8"
   - MYCC="gcc-4.8 -m32"
+  - MYCC="gcc-4.9"
+  - MYCC="gcc-4.9 -m32"
 matrix:
   fast_finish: true
 before_script:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
-  - sudo apt-get install gcc-4.8-multilib gcc-multilib build-essential
+  - sudo apt-get install gcc-4.9-multilib gcc-4.8-multilib gcc-multilib build-essential
 after_failure:
   - cat test_gcc_1.txt
   - cat test_std.txt


### PR DESCRIPTION
Extended the travis-ci file with a configuration for GCC 4.9 and also a set of jobs for compiling the shared library builds. When this is merged it will show that 32bit shared library fails.