### PR TITLE
Replace spaces with tab to file GNU make problems

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -116,7 +116,7 @@ stest: $(LIBNAME) demo/stest.o
 
 .PHONY: timing
 timing: $(LIBNAME) demo/timing.o
-    $(LT) --mode=link --tag=CC $(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o timing demo/timing.o $(LIBNAME)
+	$(LT) --mode=link --tag=CC $(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o timing demo/timing.o $(LIBNAME)
 
 # $Source$
 # $Revision$


### PR DESCRIPTION
Without this change we got the error:
johnny@m4700jw:~/ACE/fastmath> make -f makefile.shared 
makefile.shared:119: *** missing separator.  Stop.