### PR TITLE
Add missing include (prevent compiler warning)

### DIFF
--- a/src/generators/comba_sqr_gen.c
+++ b/src/generators/comba_sqr_gen.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
The atoi function used in main is defined in stdlib.h, thus the compiler created a warning before

```
gcc -o comba_sqr_gen comba_sqr_gen.c
comba_sqr_gen.c: In function ‘main’:
comba_sqr_gen.c:17:8: warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
    N = atoi(argv[1]);
```
