### PR TITLE
remove snprintf/strncat/strlen from fp_ident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ mtest
 stest
 rsatest
 timing
+ident
 *.exe

--- a/makefile
+++ b/makefile
@@ -86,6 +86,9 @@ testme: test mtest
 timing: $(LIBNAME) demo/timing.o
 	$(CC) $(CFLAGS) demo/timing.o $(LIBNAME) $(PROF) -o timing
 
+ident: $(LIBNAME)
+	$(CC) $(CFLAGS) -DSTANDALONE src/misc/fp_ident.c $(LIBNAME) $(PROF) -o ident
+
 profiled:
 	CC="$(CC)" CROSS_COMPILE="${CROSS_COMPILE} CFLAGS="${CFLAGS} -fprofile-generate" MAKE=${MAKE} ${MAKE} timing
 	./test


### PR DESCRIPTION
fp_ident is the only place tomsfast math uses string manipulation functions when built as a library. This commit replaces them with safe, trivial functions for concatenating static strings and numbers together.

This is a smaller part of a patchset to allow tomsfastmath to be compiled without stdlib, e.g. for freestanding webassembly.