### PR TITLE
allow tomsfastmath to be built without stdlib

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,7 +53,8 @@ src/sqr/fp_sqr.o src/sqr/fp_sqr_comba.o src/sqr/fp_sqr_comba_12.o src/sqr/fp_sqr
 src/sqr/fp_sqr_comba_20.o src/sqr/fp_sqr_comba_24.o src/sqr/fp_sqr_comba_28.o src/sqr/fp_sqr_comba_3.o \
 src/sqr/fp_sqr_comba_32.o src/sqr/fp_sqr_comba_4.o src/sqr/fp_sqr_comba_48.o src/sqr/fp_sqr_comba_6.o \
 src/sqr/fp_sqr_comba_64.o src/sqr/fp_sqr_comba_7.o src/sqr/fp_sqr_comba_8.o src/sqr/fp_sqr_comba_9.o \
-src/sqr/fp_sqr_comba_generic.o src/sqr/fp_sqr_comba_small_set.o src/sqr/fp_sqrmod.o
+src/sqr/fp_sqr_comba_generic.o src/sqr/fp_sqr_comba_small_set.o src/sqr/fp_sqrmod.o \
+src/misc/fp_memcpy.o src/misc/fp_memset.o
 
 HEADERS_PUB=src/headers/tfm.h
 HEADERS=src/headers/tfm_private.h $(HEADERS_PUB)

--- a/src/headers/tfm_private.h
+++ b/src/headers/tfm_private.h
@@ -19,6 +19,50 @@
 #endif
 
 /* VARIOUS LOW LEVEL STUFFS */
+#ifdef TFM_NO_STDLIB
+FP_PRIVATE void fp_memcpy(void *restrict dst, const void *restrict src, size_t n);
+FP_PRIVATE void fp_memset(void *restrict dst, unsigned char c, size_t n);
+
+#define toupper(C) __extension__({ \
+   int _c = (int)(C); \
+   'a' <= _c && 'z' >= _c ? _c - ((int)'a' - (int)'A') : _c; \
+})
+
+#define memcpy(D, S, N) __extension__({ \
+   uint8_t *_dst = (uint8_t*)(D); \
+   const uint8_t *_src = (uint8_t*)(S); \
+   size_t _n = (size_t)(N); \
+   if (__builtin_constant_p(_n)) { \
+      for (size_t _i = 0; _i < _n; ++_i) _dst[_i] = _src[_i]; \
+   } else { \
+      fp_memcpy(_dst, _src, _n); \
+   } \
+   (void *)_dst; \
+})
+
+/* The loop increment of 128 bytes was determined experimentally - it results
+ * in good inline code optimizations in both GCC and clang. */
+#define memset(D, C, N) __extension__({ \
+   uint8_t *_dst = (uint8_t*)(D); \
+   uint8_t _c = (uint8_t)(C); \
+   size_t _n = (size_t)(N); \
+   if (__builtin_constant_p(_n)) { \
+      size_t _b = _n >> 7, _r = _n & 127; \
+      for (size_t _i = 0; _i < _b; ++_i) { \
+         size_t _j = 0; \
+         for (;_j <  64; ++_j) *_dst++ = 0; \
+         for (;_j < 128; ++_j) *_dst++ = 0; \
+      } \
+      size_t _i = 0; \
+      if (_r >  0) for (;_i <  64 && _i < _r; ++_i) *_dst++ = _c; \
+      if (_r > 64) for (;_i < 128 && _i < _r; ++_i) *_dst++ = _c; \
+   } else { \
+      fp_memset(_dst, _c, _n); \
+   } \
+   (void *)_dst; \
+})
+#endif
+
 FP_PRIVATE void s_fp_add(fp_int *a, fp_int *b, fp_int *c);
 FP_PRIVATE void s_fp_sub(fp_int *a, fp_int *b, fp_int *c);
 FP_PRIVATE void fp_reverse(unsigned char *s, int len);

--- a/src/misc/fp_memcpy.c
+++ b/src/misc/fp_memcpy.c
@@ -1,0 +1,10 @@
+#include <tfm_private.h>
+
+#ifdef TFM_NO_STDLIB
+/* rely on compiler to provide optimized version */
+void fp_memcpy(void *restrict dst, const void *restrict src, size_t n) {
+  uint8_t *d = dst;
+  const uint8_t *s = src;
+  for (size_t i = 0; i < n; ++i) d[i] = s[i];
+}
+#endif

--- a/src/misc/fp_memset.c
+++ b/src/misc/fp_memset.c
@@ -1,0 +1,9 @@
+#include <tfm_private.h>
+
+#ifdef TFM_NO_STDLIB
+/* rely on compiler to provide optimized version */
+void fp_memset(void *restrict dst, unsigned char c, size_t n) {
+  uint8_t *d = dst;
+  for (size_t i = 0; i < n; ++i) d[i] = c;
+}
+#endif

--- a/src/misc/fp_rand.c
+++ b/src/misc/fp_rand.c
@@ -2,6 +2,8 @@
 /* SPDX-License-Identifier: Unlicense */
 #include <tfm_private.h>
 
+#ifdef FP_GEN_RANDOM
+
 #if FP_GEN_RANDOM_MAX == 0xffffffff
   #define FP_GEN_RANDOM_SHIFT  32
 #elif FP_GEN_RANDOM_MAX == 32767
@@ -52,3 +54,4 @@ void fp_rand(fp_int *a, int digits)
    return;
 
 }
+#endif


### PR DESCRIPTION
This commit enables tomsfastmath to be built with `--no-standard-libraries` provided `TFM_NO_STDLIB` is defined, which happens automatically if a web assembly build target is detected.

The only functionality this disables is the `fp_rand` function.

This pull request is also contains the required changes in #32 and #33.