### PR TITLE
Introduce `TFM_VERSION_3()`

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -11,6 +11,35 @@
 #define TFM_DEMO_TEST_VS_MTEST 1
 #endif
 
+static void check_version_macro(void)
+{
+   int err = 0;
+   if (!TFM_VERSION_DEV && !(TFM_VERSION == TFM_VERSION_3(TFM_VERSION_MAJ,TFM_VERSION_MIN,TFM_VERSION_PAT))) {
+      printf("Version check #1 failed \"!TFM_VERSION_DEV && !(%xu == %xu)\"\n", TFM_VERSION, TFM_VERSION_3(TFM_VERSION_MAJ,TFM_VERSION_MIN,TFM_VERSION_PAT));
+      err = 1;
+   } else {
+      printf("Version check #1 passed\n");
+   }
+
+   if (TFM_VERSION_DEV && !(TFM_VERSION > TFM_VERSION_3(TFM_VERSION_MAJ,TFM_VERSION_MIN,TFM_VERSION_PAT))) {
+      printf("Version check #2 failed \"TFM_VERSION_DEV && !(%xu > %xu)\"\n", TFM_VERSION, TFM_VERSION_3(TFM_VERSION_MAJ,TFM_VERSION_MIN,TFM_VERSION_PAT));
+      err = 1;
+   } else {
+      printf("Version check #2 passed\n");
+   }
+
+   /* TFM_VERSION_3() was only introduced after 0.13.1 so this can never be the case (hopefully) */
+   if (TFM_VERSION < TFM_VERSION_3(0,13,1)) {
+      printf("Version check #3 failed \"%xu < %xu\"\n", TFM_VERSION, TFM_VERSION_3(0,13,1));
+      err = 1;
+   } else {
+      printf("Version check #3 passed\n");
+   }
+
+   if (err)
+      exit(EXIT_FAILURE);
+}
+
 void draw(fp_int *a)
 {
   int x;
@@ -51,6 +80,8 @@ int main(void)
   printf("TFM Ident string:\n%s\n\n", fp_ident());
   fp_zero(&b); fp_zero(&c); fp_zero(&d); fp_zero(&e); fp_zero(&f);
   fp_zero(&a);
+
+  check_version_macro();
 
 #if TFM_DEMO_TEST_VS_MTEST == 0
 

--- a/src/headers/tfm.h
+++ b/src/headers/tfm.h
@@ -21,8 +21,53 @@
  * Patch
  * Development - 00=release, 01=in-development
  */
-#define TFM_VERSION     0x000D0101
-#define TFM_VERSION_S   "v0.13.1-next"
+#define TFM_VERSION_MAJ    0
+#define TFM_VERSION_MIN    13
+#define TFM_VERSION_PAT    1
+#define TFM_VERSION_DEV    1
+
+
+#define TFM_VERSION     PRIVATE__TFM_VERSION_4(TFM_VERSION_MAJ, \
+                                               TFM_VERSION_MIN, \
+                                               TFM_VERSION_PAT, \
+                                               TFM_VERSION_DEV)
+
+#define TFM_VERSION_S   PRIVATE__TFM_CONC(TFM_VERSION_MAJ, \
+                                          TFM_VERSION_MIN, \
+                                          TFM_VERSION_PAT, \
+                                          TFM_VERSION_DEV)
+
+/* Please use the `TFM_VERSION_3()` macro if you want to compile-time check
+ * for a specific TFM version.
+ * Your code could look as follows:
+
+#if TFM_VERSION <= TFM_VERSION_3(0, 13, 1)
+// do stuff to work with old TFM
+#else
+// do stuff to work with new TFM
+#endif
+
+ */
+
+#define TFM_VERSION_3(maj, min, pat) PRIVATE__TFM_VERSION_4(maj, min, pat, 0)
+
+
+/* Private stuff from here on.
+ * As said by Stanley Kirk Burrell in 1989 "You can't touch this" */
+#define PRIVATE__TFM_VERSION_4(maj, min, pat, dev) ((maj) << 24 | (min) << 16 | (pat) << 8 | (dev))
+
+#define PRIVATE__TFM_VERSION_DEV_STR_0
+#define PRIVATE__TFM_VERSION_DEV_STR_1 "-next"
+
+#define PRIVATE__TFM_VERSION_PASTE(v) PRIVATE__TFM_VERSION_DEV_STR_ ## v
+#define PRIVATE__TFM_VERSION_DEV_STR(v) PRIVATE__TFM_VERSION_PASTE(v)
+
+#define PRIVATE__TFM_STR(s) #s
+#define PRIVATE__TFM_CONC(maj, min, pat, dev) "v" PRIVATE__TFM_STR(maj) \
+                                                "." PRIVATE__TFM_STR(min) \
+                                                "." PRIVATE__TFM_STR(pat) \
+                                                PRIVATE__TFM_VERSION_DEV_STR(dev)
+/* End of private stuff */
 
 #ifndef MIN
    #define MIN(x,y) ((x)<(y)?(x):(y))


### PR DESCRIPTION
In order to be able to construct the version in a human readable format instead of a magic hex value. The `TFM_VERSION` and `TFM_VERSION_S` macros are still the same, so there's no backwards breakage here.